### PR TITLE
feat: enhance project visuals and info clarity

### DIFF
--- a/frontend-integration/src/data/projects.ts
+++ b/frontend-integration/src/data/projects.ts
@@ -3,7 +3,7 @@ import type { Project } from '../components/projects/ProjectCard';
 export const placeholderProjects: Project[] = [
   {
     id: '1',
-  thumbnailUrl: 'https://images.unsplash.com/photo-1465101046530-73398c7f28ca?auto=format&fit=crop&w=400&q=80',
+  thumbnailUrl: 'https://images.unsplash.com/photo-1504384308090-c894fdcc538d?auto=format&fit=crop&w=400&q=80', // Film: movie background
     title: 'Echoes of the Void',
     creator: 'Jane Doe',
     type: 'Film',
@@ -14,7 +14,7 @@ export const placeholderProjects: Project[] = [
   },
   {
     id: '2',
-  thumbnailUrl: 'https://images.unsplash.com/photo-1511671782779-c97d3d27a1d4?auto=format&fit=crop&w=400&q=80',
+  thumbnailUrl: 'https://images.unsplash.com/photo-1515378791036-0648a3ef77b2?auto=format&fit=crop&w=400&q=80', // Music: music background
     title: 'Cyber Sunset',
     creator: 'John Smith',
     type: 'Music',
@@ -25,7 +25,7 @@ export const placeholderProjects: Project[] = [
   },
   {
     id: '3',
-  thumbnailUrl: 'https://images.unsplash.com/photo-1506744038136-46273834b3fb?auto=format&fit=crop&w=400&q=80',
+  thumbnailUrl: 'https://images.unsplash.com/photo-1517841905240-472988babdf9?auto=format&fit=crop&w=400&q=80', // Art: artist background
     title: 'The Last Artisan',
     creator: 'Emily White',
     type: 'Art',
@@ -36,7 +36,7 @@ export const placeholderProjects: Project[] = [
   },
   {
     id: '4',
-  thumbnailUrl: 'https://images.unsplash.com/photo-1465101178521-c1a9136a3b99?auto=format&fit=crop&w=400&q=80',
+  thumbnailUrl: 'https://images.unsplash.com/photo-1519125323398-675f0ddb6308?auto=format&fit=crop&w=400&q=80', // Comedy: comedy background
     title: 'Forgotten Melodies',
     creator: 'Michael Brown',
     type: 'Podcast',
@@ -47,7 +47,7 @@ export const placeholderProjects: Project[] = [
   },
   {
     id: '5',
-  thumbnailUrl: 'https://images.unsplash.com/photo-1465101046530-73398c7f28ca?auto=format&fit=crop&w=400&q=80',
+  thumbnailUrl: 'https://images.unsplash.com/photo-1465101046530-73398c7f28ca?auto=format&fit=crop&w=400&q=80', // Film: movie background (repeat or replace as needed)
     title: 'Beneath the Surface',
     creator: 'Sarah Green',
     type: 'Animation',
@@ -58,7 +58,7 @@ export const placeholderProjects: Project[] = [
   },
   {
     id: '6',
-  thumbnailUrl: 'https://images.unsplash.com/photo-1519125323398-675f0ddb6308?auto=format&fit=crop&w=400&q=80',
+  thumbnailUrl: 'https://images.unsplash.com/photo-1465101178521-c1a9136a3b99?auto=format&fit=crop&w=400&q=80', // Comedy: comedy background (repeat or replace as needed)
     title: 'City of Glass',
     creator: 'David Black',
     type: 'Comedy',

--- a/frontend-integration/src/styles/components/ProjectCard.module.css
+++ b/frontend-integration/src/styles/components/ProjectCard.module.css
@@ -11,8 +11,8 @@
   overflow: hidden;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
   transition: transform 0.2s, box-shadow 0.2s;
-  height: 400px;
-  min-height: 340px;
+  height: 470px;
+  min-height: 400px;
   max-width: 350px;
   display: flex;
   flex-direction: column;
@@ -90,8 +90,10 @@
       font-size: 0.9rem;
     }
     .filmmaker {
-      font-size: 0.7rem;
-      color: #222;
+      font-size: 0.95rem;
+      color: #007bff;
+      font-weight: 500;
+      margin-bottom: 0.2rem;
     }
     .fundingText {
       font-size: 0.65rem;


### PR DESCRIPTION
- Use Unsplash images that match project type (movie, music, comedy, art, etc.)
- Increase project card height for better info visibility
- Style author names in blue for clear contrast on white background
- Ensure raised amount, target amount, and days remaining are always visible